### PR TITLE
Escape login identifier before searching the entry.

### DIFF
--- a/pyramid_ldap/__init__.py
+++ b/pyramid_ldap/__init__.py
@@ -1,5 +1,6 @@
 try:
     import ldap
+    import ldap.filter
 except ImportError: # pragma: no cover
     # this is for benefit of being able to build the docs on rtd.org
     class ldap(object):
@@ -113,8 +114,10 @@ class Connector(object):
             if search is None:
                 raise ConfigurationError(
                     'ldap_set_login_query was not called during setup')
-            
-            result = search.execute(conn, login=login, password=password)
+
+            escaped_login = ldap.filter.escape_filter_chars(login)
+
+            result = search.execute(conn, login=escaped_login, password=password)
             if len(result) == 1:
                 login_dn = result[0][0]
             else:


### PR DESCRIPTION
This will avoid trivial DOS and ldap.FILTER_ERROR exceptions on
attempted logins by users sporting "funny" login names, like 'user*name'
or 'user(middle)name'.
