### PR TITLE
Added check for zero length password w/ tests and docs (Fixes Issue #9)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -270,7 +270,13 @@ The LDAP connector instance has an
 and password.  It will return a data structure containing the user's DN as
 well as the user attributes if the user exists and his password is correct.
 It will return ``None`` if the user doesn't exist or if the user exists and
-his password is incorrect.
+his password is incorrect. A zero length password is always considered invalid
+since it is, according to the LDAP spec, a request for "unauthenticated
+authentication." Unauthenticated authentication should not be used for LDAP
+based authentication.
+
+See `section 5.1.2 of RFC-4513 <http://tools.ietf.org/html/rfc4513#section-5.1.2>`_
+for a description of this behavior.
 
 When the user's name and password are correct, the ``login`` view uses the
 ``pyramid.security.remember`` API to set headers indicating that the user is

--- a/pyramid_ldap/__init__.py
+++ b/pyramid_ldap/__init__.py
@@ -105,9 +105,18 @@ class Connector(object):
         from UTF-8, recursively, where possible.  The dictionary returned is
         a case-insensitive dictionary implemenation.
 
+        A zero length password will always be considered invalid since it
+        results in a request for "unauthenticated authentication" which should
+        not be used for LDAP based authentication. See `section 5.1.2 of
+        RFC-4513 <http://tools.ietf.org/html/rfc4513#section-5.1.2>`_ for a
+        description of this behavior.
+
         If :meth:`pyramid.config.Configurator.ldap_set_login_query` was not
         called, using this function will raise an
         :exc:`pyramid.exceptions.ConfiguratorError`."""
+        if password == '':
+            return None
+            
         with self.manager.connection() as conn:
             search = getattr(self.registry, 'ldap_login_query', None)
             if search is None:

--- a/pyramid_ldap/tests.py
+++ b/pyramid_ldap/tests.py
@@ -154,6 +154,13 @@ class TestConnector(unittest.TestCase):
         inst = self._makeOne(registry, manager)
         self.assertEqual(inst.authenticate(None, None), None)
 
+    def test_authenticate_empty_password(self):
+        manager = DummyManager()
+        registry = Dummy()
+        registry.ldap_login_query = DummySearch([('a', 'b')])
+        inst = self._makeOne(registry, manager)
+        self.assertEqual(inst.authenticate('foo', ''), None)
+
     def test_authenticate_search_returns_one_result(self):
         manager = DummyManager()
         registry = Dummy()


### PR DESCRIPTION
Fixing the issue of allowing users to authenticate through LDAP with a zero length password via "unathenticated authentication." Let me know if I'm missing anything in the pull request and I will fix.
