### PR TITLE
handle OPT_REFERRALS being set to 0

### DIFF
--- a/pyramid_ldap/__init__.py
+++ b/pyramid_ldap/__init__.py
@@ -124,7 +124,11 @@ class Connector(object):
                     'ldap_set_login_query was not called during setup')
             
             result = search.execute(conn, login=login, password=password)
-            if len(result) == 1:
+            expected_results = 1
+            if conn.get_option(ldap.OPT_REFERRALS) == 0:
+                expected_results = 2
+
+            if len(result) == expected_results:
                 login_dn = result[0][0]
             else:
                 return None


### PR DESCRIPTION
When performing a search with OPT_REFERRALS being set to 0 (which allows
quering from the root of the directory) you end up with 2 results on a
successful search, or 1 on a failed search. This has only been tested on
Active Directory so I can't say for certain the behaviour under a
different LDAP system.
