### PR TITLE
Patched escape sequence issue due to having escape commas in our userdns

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,13 @@ Next release
 - Prevent the use of zero-length password authentication.  See
   https://github.com/Pylons/pyramid_ldap/pull/13
 
-0.1
+0.2
 ---
+
+-  Patched escape sequence issue:
+
+    http://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx
+
+    "The backslash character must be escaped in LDAP filters. Substitute \5C"
 
 -  Initial version

--- a/pyramid_ldap/__init__.py
+++ b/pyramid_ldap/__init__.py
@@ -288,6 +288,7 @@ def groupfinder(userdn, request):
     principal in the list of results; if the user does not exist, it returns
     None."""
     connector = get_ldap_connector(request)
+    userdn = userdn.replace('\\', '\\5c')
     group_list = connector.user_groups(userdn)
     if group_list is None:
         return None

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ testing_extras = ['nose', 'coverage']
 docs_extras = ['Sphinx']
 
 setup(name='pyramid_ldap',
-      version='0.1',
+      version='0.2',
       description='pyramid_ldap',
       long_description=README + '\n\n' +  CHANGES,
       classifiers=[


### PR DESCRIPTION
At my company our userdn's contain escaped commas. ex:

CN=Bandt\, Aaron,OU=Department,OU=Group, etc...

When the groupfinder attempts to use that in the query for groups, it fails due to the '\' not being properly escaped for use in a query. Added one line to appropriately insert the correct escape sequence if the backslash is present in the userdn.